### PR TITLE
Fix --tab error

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -23,7 +23,7 @@ src_obconf_CPPFLAGS = \
 	$(XML_CFLAGS) \
 	-DLOCALEDIR=\"$(localedir)\" \
 	-DPIXMAPDIR=\"$(pixmapdir)\" \
-	-DGLADEDIR=\"$(gladedir)\" \
+	-DRESOURCEDIR=\"$(resourcedir)\" \
 	-DTHEMEDIR=\"$(themedir)\" \
 	-DG_LOG_DOMAIN=\"Obconf\"
 src_obconf_LDADD = \

--- a/src/main.c
+++ b/src/main.c
@@ -131,8 +131,10 @@ static void parse_args(int argc, char **argv)
         else if (!strcmp(argv[i], "--tab")) {
             if (i == argc - 1) /* no args left */
                 g_printerr(_("--tab requires an argument\n"));
-            else
-                obc_tab = MAX(atoi(argv[++i]) - 1, 0);
+            else {
+                obc_tab = atoi(argv[++i]) - 1;
+                obc_tab = MAX(obc_tab, 0); /* tab number should not be negative */
+            }
         }
         else
             obc_theme_install = argv[i];

--- a/src/main.c
+++ b/src/main.c
@@ -218,7 +218,7 @@ int main(int argc, char **argv)
         return 0;
     }
 
-    p = g_build_filename(GLADEDIR, "obconf.ui", NULL);
+    p = g_build_filename(RESOURCEDIR, "obconf.ui", NULL);
     builder = gtk_builder_new();
     gtk_builder_add_from_file(builder, p, &error);
     g_free(p);


### PR DESCRIPTION
The error occurs when a tab number greater than one is given, which will
cause obconf to crash with a segmentation violation. For example, typing
'obconf --tab 2' on the console will crash insteading of launching a GUI
with tab 2 selected. The error is caused by using the MAX macro with a
first argument that is not an idempotent expression (file main.c, line
number 135):

    obc_tab = MAX(atoi(argv[++i]) - 1, 0);

where MAX is defined in file /usr/include/x86_64-linux-gnu/sys/param.h:

    #define MAX(a,b) (((a)>(b))?(a):(b))

where the result will be the first argument a if it is more than the
second argument b, otherwise the result will be b, ie, the result will
be the maximum of a or b. Notice that a or b will be evaluated twice,
depending on the > comparison, which means that a and b should always be
idempotent expression, assuming that the compiler does not generate code
to cache a and b values as intermediate results.

In our case, if the argument counter i is zero or one, a will be
evaluated once, but if it is two or more, a will be evaluated twice,
which means that the argv array will be accessed past its natural end.