### PR TITLE
Drop old mimelnk MIME type

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -7,7 +7,6 @@ themedir        = $(datadir)/openbox/themes
 desktopdir      = $(datadir)/applications
 mimedir         = $(datadir)/mime
 mimepkgdir      = $(datadir)/mime/packages
-kdemimedir      = $(datadir)/mimelnk/application
 
 AUTOMAKE_OPTIONS = subdir-objects foreign
 ACLOCAL_AMFLAGS = -I m4
@@ -73,9 +72,6 @@ dist_desktop_DATA = \
 
 dist_mimepkg_DATA = \
 	obconf.xml
-
-dist_kdemime_DATA = \
-	x-openbox-theme.desktop
 
 dist_pixmap_DATA = \
 	data/obconf.png

--- a/x-openbox-theme.desktop
+++ b/x-openbox-theme.desktop
@@ -1,8 +1,0 @@
-[Desktop Entry]
-Encoding=UTF-8
-Type=MimeType
-MimeType=application/x-openbox-theme
-Icon=openbox
-Patterns=*.obt;
-Comment=Openbox Theme Archive
-Comment[ru]=Архив темы Openbox


### PR DESCRIPTION
Those desktop MIME types were needed only with KDE up to 3.x, as it
used to have its own desktop-based MIME type system. KDE 3 is EOL for
many years now, and there are already XDG MIME types.