### PR TITLE
Fix build errors with GCC 15

### DIFF
--- a/src/appearance.c
+++ b/src/appearance.c
@@ -21,6 +21,8 @@
 #include "tree.h"
 #include "preview_update.h"
 
+#include <ctype.h>
+
 static gboolean mapping = FALSE;
 
 static RrFont *read_font(GtkFontButton *w, const gchar *place, gboolean def);

--- a/src/desktops.h
+++ b/src/desktops.h
@@ -24,5 +24,6 @@
 
 void desktops_setup_num(GtkWidget *w);
 void desktops_setup_names(GtkWidget *w);
+void desktops_setup_tab();
 
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -266,7 +266,7 @@ int main(int argc, char **argv)
 
     /* look for parsing errors */
     {
-        xmlErrorPtr e = xmlGetLastError();
+        const xmlError *e = xmlGetLastError();
         if (e) {
             char *a = g_strdup_printf
                 (_("Error while parsing the Openbox configuration file.  Your configuration file is not valid XML.\n\nMessage: %s"),

--- a/src/main.c
+++ b/src/main.c
@@ -28,6 +28,7 @@
 #include "dock.h"
 #include "preview_update.h"
 #include "gettext.h"
+#include "moveresize.h"
 
 #include <gdk/gdkx.h>
 #define SN_API_NOT_YET_FROZEN


### PR DESCRIPTION
Fix some errors and warnings that are produced when compiling obconf with GCC 15, which defaults to the C23 language standard.

I've also included a fix for a warning with recent versions of libxml2.